### PR TITLE
Add Codespaces setup

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,2 +1,3 @@
 SSH_USER=hsf-user
 SSH_PASSWORD=hsf-password
+SERVER_URL=hsf-training.org

--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,0 +1,2 @@
+SSH_USER=hsf-user
+SSH_PASSWORD=hsf-password

--- a/.devcontainer/Dockerfile-main
+++ b/.devcontainer/Dockerfile-main
@@ -1,0 +1,5 @@
+FROM docker:latest
+
+ARG SERVER_URL
+
+RUN sudo echo "127.0.0.1   ${SERVER_URL}" > /etc/hosts

--- a/.devcontainer/Dockerfile-main
+++ b/.devcontainer/Dockerfile-main
@@ -1,5 +1,0 @@
-FROM docker:latest
-
-ARG SERVER_URL
-
-RUN sudo echo "127.0.0.1   ${SERVER_URL}" > /etc/hosts

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "name": "SSH training",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "devcontainer",
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  devcontainer:
+    platform: linux/x86_64
+    image: docker:latest
+    container_name: devcontainer
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: sleep infinity
+    network_mode: host
+    depends_on:
+      - openssh-server
+
+  openssh-server:
+    image: lscr.io/linuxserver/openssh-server:latest
+    container_name: openssh-server
+    hostname: openssh-server
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+      #- PUBLIC_KEY=yourpublickey #optional
+      #- PUBLIC_KEY_FILE=/path/to/file #optional
+      #- PUBLIC_KEY_DIR=/path/to/directory/containing/_only_/pubkeys #optional
+      #- PUBLIC_KEY_URL=https://github.com/username.keys #optional
+      - SUDO_ACCESS=true #optional
+      - PASSWORD_ACCESS=true #optional
+      - USER_PASSWORD=${SSH_PASSWORD} #optional
+      #- USER_PASSWORD_FILE=/path/to/file #optional
+      - USER_NAME=${SSH_USER} #optional
+      - LOG_STDOUT= #optional
+    volumes:
+      - /path/to/openssh-server/config:/config
+    ports:
+      - 2222:2222
+    restart: unless-stopped

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,11 @@
 services:
   devcontainer:
     platform: linux/x86_64
-    image: docker:latest
+    build:
+      context: .
+      dockerfile: Dockerfile-main
+      args:
+        SERVER_URL: ${SERVER_URL}
     container_name: devcontainer
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -31,5 +35,5 @@ services:
     volumes:
       - /path/to/openssh-server/config:/config
     ports:
-      - 2222:2222
+      - 22:2222
     restart: unless-stopped

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,11 +1,9 @@
 services:
   devcontainer:
     platform: linux/x86_64
-    build:
-      context: .
-      dockerfile: Dockerfile-main
-      args:
-        SERVER_URL: ${SERVER_URL}
+    image: docker:latest
+    extra_hosts:
+      - "${SERVER_URL}:127.0.0.1"
     container_name: devcontainer
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
I'm adding a setup for GH Codespaces so that people can try SSHing into a test server without them having to worry about about messing something up, and without us having to worry about hosting a test server open to anyone.

My initial plan was to try starting a GH Codespace and open a port so that users would be able to SSH from their computer. However, GH has this pretty locked down, and ports basically only works for http servers. So instead what I did was to set up some a Docker container and set up a host with a real url that we control so that there's no risk of someone else trying to do something bad with it.

So the way it's currently set up works as follows. You start the Codespace and wait for it to load. Then you can do
```bash
ssh hsf-user@hsf-training.org
```
with the password being `hsf-password`. You will be dropped into a shell in the container.

It already works, but I'm marking this as a draft so I can clean it up a bit and so we can discuss what we want to put in the "local" and "remote" parts so that users can play with (e.g. some data that they can `scp`).